### PR TITLE
Feature calculate bounding boxes

### DIFF
--- a/unit-registry/core/src/main/java/org/openbase/bco/registry/unit/core/UnitRegistryController.java
+++ b/unit-registry/core/src/main/java/org/openbase/bco/registry/unit/core/UnitRegistryController.java
@@ -345,8 +345,8 @@ public class UnitRegistryController extends AbstractRegistryController<UnitRegis
         sceneUnitConfigRegistry.registerConsistencyHandler(new SceneLabelConsistencyHandler());
         sceneUnitConfigRegistry.registerConsistencyHandler(new SceneScopeConsistencyHandler(locationUnitConfigRegistry));
 
-        // add consistency handler for all unitConfig registries
-        registerConsistencyHandler(new BoundingBoxCleanerConsistencyHandler(), UnitConfig.class);
+        // add consistency handler for all unitConfig registries        
+       
         registerConsistencyHandler(new ServiceConfigUnitIdConsistencyHandler(), UnitConfig.class);
         registerConsistencyHandler(new UnitConfigUnitTemplateConsistencyHandler(unitTemplateRegistry), UnitConfig.class);
         registerConsistencyHandler(new UnitEnablingStateConsistencyHandler(), UnitConfig.class);
@@ -359,6 +359,7 @@ public class UnitRegistryController extends AbstractRegistryController<UnitRegis
         } catch (JPNotAvailableException ex) {
             // do nothing if not available.
         }
+        registerConsistencyHandler(new BoundingBoxCleanerConsistencyHandler(), UnitConfig.class);
     }
 
     /**

--- a/unit-registry/core/src/main/java/org/openbase/bco/registry/unit/core/UnitRegistryController.java
+++ b/unit-registry/core/src/main/java/org/openbase/bco/registry/unit/core/UnitRegistryController.java
@@ -338,6 +338,7 @@ public class UnitRegistryController extends AbstractRegistryController<UnitRegis
 
         // add consistency handler for all unitConfig registries        
        
+        registerConsistencyHandler(new BoundingBoxCleanerConsistencyHandler(), UnitConfig.class);
         registerConsistencyHandler(new ServiceConfigUnitIdConsistencyHandler(), UnitConfig.class);
         registerConsistencyHandler(new UnitConfigUnitTemplateConsistencyHandler(unitTemplateRegistry), UnitConfig.class);
         registerConsistencyHandler(new UnitEnablingStateConsistencyHandler(), UnitConfig.class);
@@ -350,7 +351,6 @@ public class UnitRegistryController extends AbstractRegistryController<UnitRegis
         } catch (JPNotAvailableException ex) {
             // do nothing if not available.
         }
-        registerConsistencyHandler(new BoundingBoxCleanerConsistencyHandler(), UnitConfig.class);
     }
 
     /**

--- a/unit-registry/core/src/main/java/org/openbase/bco/registry/unit/core/UnitRegistryController.java
+++ b/unit-registry/core/src/main/java/org/openbase/bco/registry/unit/core/UnitRegistryController.java
@@ -29,6 +29,7 @@ import org.openbase.bco.registry.agent.remote.AgentRegistryRemote;
 import org.openbase.bco.registry.app.remote.AppRegistryRemote;
 import org.openbase.bco.registry.device.remote.DeviceRegistryRemote;
 import org.openbase.bco.registry.lib.com.AbstractRegistryController;
+import org.openbase.bco.registry.unit.core.consistency.BoundingBoxCleanerConsistencyHandler;
 import org.openbase.bco.registry.unit.core.consistency.DeviceInventoryStateConsistencyHandler;
 import org.openbase.bco.registry.unit.core.consistency.ExecutableUnitAutostartConsistencyHandler;
 import org.openbase.bco.registry.unit.core.consistency.ServiceConfigServiceTemplateIdConsistencyHandler;
@@ -348,6 +349,7 @@ public class UnitRegistryController extends AbstractRegistryController<UnitRegis
         sceneUnitConfigRegistry.registerConsistencyHandler(new SceneScopeConsistencyHandler(locationUnitConfigRegistry));
 
         // add consistency handler for all unitConfig registries
+        registerConsistencyHandler(new BoundingBoxCleanerConsistencyHandler(), UnitConfig.class);
         registerConsistencyHandler(new ServiceConfigUnitIdConsistencyHandler(), UnitConfig.class);
         registerConsistencyHandler(new UnitConfigUnitTemplateConsistencyHandler(unitTemplateRegistry), UnitConfig.class);
         registerConsistencyHandler(new UnitEnablingStateConsistencyHandler(), UnitConfig.class);

--- a/unit-registry/core/src/main/java/org/openbase/bco/registry/unit/core/consistency/BoundingBoxCleanerConsistencyHandler.java
+++ b/unit-registry/core/src/main/java/org/openbase/bco/registry/unit/core/consistency/BoundingBoxCleanerConsistencyHandler.java
@@ -71,11 +71,11 @@ public class BoundingBoxCleanerConsistencyHandler extends AbstractProtoBufRegist
 
     private AxisAlignedBoundingBox3DFloat updateBoundingBox(final Shape shape) {
 
-        double maxX = 0.0;
+        double maxX = Double.MIN_VALUE;
         double minX = Double.MAX_VALUE;
-        double maxY = 0.0;
+        double maxY = Double.MIN_VALUE;
         double minY = Double.MAX_VALUE;
-        double maxZ = 0.0;
+        double maxZ = Double.MIN_VALUE;
         double minZ = Double.MAX_VALUE;
 
         // Get the shape of the room

--- a/unit-registry/core/src/main/java/org/openbase/bco/registry/unit/core/consistency/BoundingBoxCleanerConsistencyHandler.java
+++ b/unit-registry/core/src/main/java/org/openbase/bco/registry/unit/core/consistency/BoundingBoxCleanerConsistencyHandler.java
@@ -1,0 +1,126 @@
+package org.openbase.bco.registry.unit.core.consistency;
+
+/*
+ * #%L
+ * BCO Registry Unit Core
+ * %%
+ * Copyright (C) 2014 - 2017 openbase.org
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+import java.util.List;
+import javax.vecmath.Point3d;
+import org.openbase.bco.registry.unit.core.consistency.*;
+import org.openbase.jul.exception.CouldNotPerformException;
+import org.openbase.jul.extension.protobuf.IdentifiableMessage;
+import org.openbase.jul.extension.protobuf.container.ProtoBufMessageMap;
+import org.openbase.jul.storage.registry.AbstractProtoBufRegistryConsistencyHandler;
+import org.openbase.jul.storage.registry.EntryModification;
+import org.openbase.jul.storage.registry.ProtoBufRegistry;
+import rst.domotic.unit.UnitConfigType.UnitConfig;
+import rst.domotic.unit.UnitTemplateType;
+import rst.geometry.AxisAlignedBoundingBox3DFloatType;
+import rst.geometry.AxisAlignedBoundingBox3DFloatType.AxisAlignedBoundingBox3DFloat;
+import rst.geometry.PoseType.Pose;
+import rst.geometry.TranslationType.Translation;
+import rst.math.Vec3DDoubleType;
+import rst.spatial.ShapeType;
+import rst.spatial.ShapeType.Shape;
+
+/**
+ *
+ * @author <a href="mailto:pleminoq@openbase.org">Tamino Huxohl</a>
+ */
+public class BoundingBoxCleanerConsistencyHandler extends AbstractProtoBufRegistryConsistencyHandler<String, UnitConfig, UnitConfig.Builder> {
+
+    @Override
+    public void processData(String id, IdentifiableMessage<String, UnitConfig, UnitConfig.Builder> entry, ProtoBufMessageMap<String, UnitConfig, UnitConfig.Builder> entryMap, ProtoBufRegistry<String, UnitConfig, UnitConfig.Builder> registry) throws CouldNotPerformException, EntryModification {
+        UnitConfig.Builder unitConfig = entry.getMessage().toBuilder();
+
+        //todo boundingbox included in all types?
+        if (unitConfig.hasPlacementConfig() && unitConfig.getPlacementConfig().hasShape()) {
+
+            Shape shape = unitConfig.getPlacementConfig().getShape();
+
+            if (!shape.hasBoundingBox()) {
+                return;
+            }
+
+            AxisAlignedBoundingBox3DFloat bb = shape.getBoundingBox();
+            AxisAlignedBoundingBox3DFloat newBB;
+            
+            newBB = updateBB(shape); 
+            
+            //detect changes
+            if(bb.getDepth() != newBB.getDepth()
+                || bb.getHeight() != newBB.getHeight()
+                || bb.getWidth() != newBB.getWidth()
+                || bb.getLeftFrontBottom() != newBB.getLeftFrontBottom()){
+                
+                unitConfig.getPlacementConfigBuilder().getShapeBuilder().setBoundingBox(newBB);
+                throw new EntryModification(entry.setMessage(unitConfig), this);
+            }
+           
+        }
+    }
+
+    private AxisAlignedBoundingBox3DFloat updateBB(Shape shape) {
+
+        double maxX = 0.0;
+        double minX = Double.MAX_VALUE;
+        double maxY = 0.0;
+        double minY = Double.MAX_VALUE;
+        double maxZ = 0.0;
+        double minZ = Double.MAX_VALUE;
+
+        // Get the shape of the room
+        final List<Vec3DDoubleType.Vec3DDouble> roomShape = shape.getFloorList();
+
+        // Iterate over all vertices
+        for (final Vec3DDoubleType.Vec3DDouble rstVertex : roomShape) {
+            if (rstVertex.getX() < minX) {
+                minX = rstVertex.getX();
+            }
+            if (rstVertex.getX() > maxX) {
+                maxX = rstVertex.getX();
+            }
+            if (rstVertex.getY() < minY) {
+                minY = rstVertex.getY();
+            }
+            if (rstVertex.getY() > maxY) {
+                maxY = rstVertex.getY();
+            }
+            if (rstVertex.getZ() < minZ) {
+                minZ = rstVertex.getZ();
+            }
+            if (rstVertex.getZ() > maxZ) {
+                maxZ = rstVertex.getZ();
+            }
+        }
+        AxisAlignedBoundingBox3DFloat.Builder builder = AxisAlignedBoundingBox3DFloat.newBuilder();
+        builder.setDepth((float)(maxY - minY));
+        builder.setHeight((float) (maxZ-minZ));
+        builder.setWidth((float) (maxX-minX));
+        Translation.Builder translationBuilder = Translation.newBuilder().setX(0).setY(0).setZ(0);
+        builder.setLeftFrontBottom(translationBuilder);
+        
+        AxisAlignedBoundingBox3DFloat newBB = builder.build();
+        
+        return newBB;
+    }
+}
+
+

--- a/unit-registry/core/src/main/java/org/openbase/bco/registry/unit/core/consistency/BoundingBoxCleanerConsistencyHandler.java
+++ b/unit-registry/core/src/main/java/org/openbase/bco/registry/unit/core/consistency/BoundingBoxCleanerConsistencyHandler.java
@@ -34,10 +34,7 @@ import rst.geometry.TranslationType.Translation;
 import rst.math.Vec3DDoubleType;
 import rst.spatial.ShapeType.Shape;
 
-/**
- *
- * @author <a href="mailto:pleminoq@openbase.org">Tamino Huxohl</a>
- */
+
 public class BoundingBoxCleanerConsistencyHandler extends AbstractProtoBufRegistryConsistencyHandler<String, UnitConfig, UnitConfig.Builder> {
 
     @Override
@@ -51,15 +48,10 @@ public class BoundingBoxCleanerConsistencyHandler extends AbstractProtoBufRegist
 
         Shape shape = unitConfig.getPlacementConfig().getShape();
 
-        if (!shape.hasBoundingBox()) {
-            return;
-        }
-        //TODO clean out empty bounding boxes?   
-
         AxisAlignedBoundingBox3DFloat newBoundingBox = updateBoundingBox(shape);
 
         //detect changes
-   //     if(!shape.getBoundingBox().equals(newBoundingBox)) {
+   //     if(!shape.getBoundingBox().equals(newBoundingBox)) { // todo test, didn't seem to work
         if (shape.getBoundingBox().getDepth() != newBoundingBox.getDepth()
             || shape.getBoundingBox().getHeight() != newBoundingBox.getHeight()
             || shape.getBoundingBox().getWidth() != newBoundingBox.getWidth()) {

--- a/unit-registry/test/src/test/java/org/openbase/bco/registry/unit/test/DeviceRegistryTest.java
+++ b/unit-registry/test/src/test/java/org/openbase/bco/registry/unit/test/DeviceRegistryTest.java
@@ -359,6 +359,8 @@ public class DeviceRegistryTest {
     public void testBoundingBoxConsistencyHandler() throws Exception {
         // how to get a test unit?
         UnitConfig testUnit = UnitConfig.newBuilder().setType(UnitTemplate.UnitType.COLORABLE_LIGHT).build();
+        
+       // UnitConfig testUnit = deviceRegistry.getDeviceConfigById("PH_Hue_E27_Device");
         TranslationType.Translation.Builder translationBuilder = TranslationType.Translation.newBuilder().setX(0).setY(0).setZ(0);
         Vec3DDoubleType.Vec3DDouble vector1 = Vec3DDoubleType.Vec3DDouble.newBuilder().setX(0.1).setY(4.2).setZ(0.0).build();
         Vec3DDoubleType.Vec3DDouble vector2 = Vec3DDoubleType.Vec3DDouble.newBuilder().setX(3.6).setY(0.0).setZ(0.0).build();
@@ -368,7 +370,7 @@ public class DeviceRegistryTest {
         ShapeType.Shape shapeBuilder =  ShapeType.Shape.newBuilder().addAllFloor(values).build();
         testUnit.toBuilder().getPlacementConfigBuilder().setShape(shapeBuilder);
         
-        //unitRegistry.registerUnitConfig(testDevice).get();
+        //deviceRegistry.updateDeviceConfig(testUnit).get(); 
         
         ShapeType.Shape shape = testUnit.getPlacementConfig().getShape();
         

--- a/unit-registry/test/src/test/java/org/openbase/bco/registry/unit/test/DeviceRegistryTest.java
+++ b/unit-registry/test/src/test/java/org/openbase/bco/registry/unit/test/DeviceRegistryTest.java
@@ -23,6 +23,7 @@ package org.openbase.bco.registry.unit.test;
  */
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import static junit.framework.TestCase.assertEquals;
@@ -67,11 +68,15 @@ import rst.domotic.unit.device.DeviceClassType.DeviceClass;
 import rst.domotic.unit.device.DeviceConfigType.DeviceConfig;
 import rst.domotic.unit.location.LocationConfigType.LocationConfig;
 import rst.domotic.unit.user.UserConfigType.UserConfig;
+import rst.geometry.AxisAlignedBoundingBox3DFloatType;
 import rst.geometry.PoseType;
 import rst.geometry.RotationType;
 import rst.geometry.TranslationType;
+import rst.math.Vec3DDoubleType;
+import rst.math.Vec3DDoubleType.Vec3DDouble;
 import rst.rsb.ScopeType;
 import rst.spatial.PlacementConfigType.PlacementConfig;
+import rst.spatial.ShapeType;
 
 /**
  *
@@ -348,6 +353,32 @@ public class DeviceRegistryTest {
             assertTrue("DalUnit [" + dalUnitConfig.getLabel() + "] still registered even though its device has been removed!", !unitRegistry.containsUnitConfig(dalUnitConfig));
         }
 
+    }
+    
+    @Test(timeout = 5000)
+    public void testBoundingBoxConsistencyHandler() throws Exception {
+        // how to get a test unit?
+        UnitConfig testUnit = UnitConfig.newBuilder().setType(UnitTemplate.UnitType.COLORABLE_LIGHT).build();
+        TranslationType.Translation.Builder translationBuilder = TranslationType.Translation.newBuilder().setX(0).setY(0).setZ(0);
+        Vec3DDoubleType.Vec3DDouble vector1 = Vec3DDoubleType.Vec3DDouble.newBuilder().setX(0.1).setY(4.2).setZ(0.0).build();
+        Vec3DDoubleType.Vec3DDouble vector2 = Vec3DDoubleType.Vec3DDouble.newBuilder().setX(3.6).setY(0.0).setZ(0.0).build();
+        Vec3DDoubleType.Vec3DDouble vector3 = Vec3DDoubleType.Vec3DDouble.newBuilder().setX(5.1).setY(2.9).setZ(0.0).build();
+        Vec3DDoubleType.Vec3DDouble vector4 = Vec3DDoubleType.Vec3DDouble.newBuilder().setX(2.7).setY(2.1).setZ(0.0).build();
+        ArrayList<Vec3DDouble> values = new ArrayList<>(Arrays.asList(vector1, vector2, vector3, vector4)); 
+        ShapeType.Shape shapeBuilder =  ShapeType.Shape.newBuilder().addAllFloor(values).build();
+        testUnit.toBuilder().getPlacementConfigBuilder().setShape(shapeBuilder);
+        
+        //unitRegistry.registerUnitConfig(testDevice).get();
+        
+        ShapeType.Shape shape = testUnit.getPlacementConfig().getShape();
+        
+        AxisAlignedBoundingBox3DFloatType.AxisAlignedBoundingBox3DFloat.Builder builder = AxisAlignedBoundingBox3DFloatType.AxisAlignedBoundingBox3DFloat.newBuilder();
+        builder.setDepth((float) (4.2));
+        builder.setHeight((float) (0.0));
+        builder.setWidth((float) (5.0));
+        TranslationType.Translation.Builder lfbBuilder = TranslationType.Translation.newBuilder().setX(0.1).setY(0.0).setZ(0.0);
+        builder.setLeftFrontBottom(translationBuilder);
+        //assertTrue(shape.getBoundingBox().equals(builder.build()));
     }
 
     @Test(timeout = 5000)


### PR DESCRIPTION
The bounding boxes for all units with a shape are checked with a new consistency handler and updated if necessary. The test for the device registry (DeviceRegistryTest.java) contains a new test that needs to be completed because I did not find the already registered devices in the mock registry. If necessary, this test could be included and completed, maybe with additional cases.